### PR TITLE
Rename key to StringValue on experimentKey and experimentVariantKey

### DIFF
--- a/features/featuretoggles/src/main/kotlin/ru/pixnews/features/featuretoggles/FeatureToggleListViewModel.kt
+++ b/features/featuretoggles/src/main/kotlin/ru/pixnews/features/featuretoggles/FeatureToggleListViewModel.kt
@@ -62,7 +62,7 @@ internal class FeatureToggleListViewModel(
         )
     private val togglesMap: Map<ExperimentKey, FeatureToggle<Experiment>> = featureManager.featureToggles.values
         .toList()
-        .sortedWith(compareBy({ it.experiment.key.key }, { it.experiment.name }, { it.experiment.description }))
+        .sortedWith(compareBy({ it.experiment.key.stringValue }, { it.experiment.name }, { it.experiment.description }))
         .associateBy { it.experiment.key }
 
     private suspend fun getScreenContent(

--- a/features/featuretoggles/src/main/kotlin/ru/pixnews/features/featuretoggles/ui/FeatureToggleListPopulated.kt
+++ b/features/featuretoggles/src/main/kotlin/ru/pixnews/features/featuretoggles/ui/FeatureToggleListPopulated.kt
@@ -81,7 +81,7 @@ internal fun FeatureToggleListPopulated(
             contentPadding = paddingValues,
         ) {
             for (toggle in toggles) {
-                item(key = toggle.key.key, contentType = toggle.type) {
+                item(key = toggle.key.stringValue, contentType = toggle.type) {
                     ToggleListItem(
                         toggle = toggle,
                         onResetExperimentOverrideClicked = { onResetExperimentOverrideClicked(toggle.key) },
@@ -119,7 +119,7 @@ internal fun ToggleListItem(
                 .padding(horizontal = 16.dp, vertical = 12.dp),
         ) {
             Text(
-                text = toggle.key.key,
+                text = toggle.key.stringValue,
                 style = MaterialTheme.typography.labelMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
@@ -168,7 +168,7 @@ private fun GroupSelectionRow(
             GroupSelectionDropdown(
                 modifier = Modifier
                     .width(200.dp),
-                selectedKey = toggle.activeVariant.key,
+                selectedKey = toggle.activeVariant.stringValue,
                 variants = toggle.variants,
                 onVariantSelected = onExperimentVariantSelected,
             )
@@ -245,7 +245,7 @@ private fun VariantDropdownMenu(
                     verticalArrangement = Arrangement.Center,
                 ) {
                     Text(
-                        text = variant.key.key,
+                        text = variant.key.stringValue,
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurface,
                         maxLines = 1,

--- a/foundation/featuretoggles/datasource-firebase/src/main/kotlin/ru/pixnews/foundation/featuretoggles/datasource/firebase/FirebaseDataSource.kt
+++ b/foundation/featuretoggles/datasource-firebase/src/main/kotlin/ru/pixnews/foundation/featuretoggles/datasource/firebase/FirebaseDataSource.kt
@@ -95,7 +95,7 @@ public class FirebaseDataSource(
                 emit(Loading)
                 initFirebaseJob.join()
             }
-            val value = remoteConfig.getValue(experimentKey.key)
+            val value = remoteConfig.getValue(experimentKey.stringValue)
             if (value.source != FirebaseRemoteConfig.VALUE_SOURCE_STATIC) {
                 val serialized = value.asString()
                 val activeVariant = serializers[experimentKey]?.fromString(experimentKey, serialized)

--- a/foundation/featuretoggles/datasource-firebase/src/main/kotlin/ru/pixnews/foundation/featuretoggles/datasource/firebase/FirebaseRemoteConfigModule.kt
+++ b/foundation/featuretoggles/datasource-firebase/src/main/kotlin/ru/pixnews/foundation/featuretoggles/datasource/firebase/FirebaseRemoteConfigModule.kt
@@ -47,7 +47,7 @@ public object FirebaseRemoteConfigModule {
         serializers: Map<@JvmSuppressWildcards ExperimentKey, @JvmSuppressWildcards ExperimentVariantSerializer>,
     ): Map<String, String> {
         return experiments
-            .groupingBy { experiment -> experiment.key.key }
+            .groupingBy { experiment -> experiment.key.stringValue }
             .reduce { key, _, element ->
                 throw DuplicateExperimentException("Duplicate key '$key' encountered for element '$element'")
             }

--- a/foundation/featuretoggles/datasource-firebase/src/test/kotlin/ru/pixnews/foundation/featuretoggles/datasource/firebase/FirebaseDataSourceTest.kt
+++ b/foundation/featuretoggles/datasource-firebase/src/test/kotlin/ru/pixnews/foundation/featuretoggles/datasource/firebase/FirebaseDataSourceTest.kt
@@ -91,7 +91,9 @@ class FirebaseDataSourceTest {
 
     @Test
     fun `getAssignedVariant() should return valid remote config variant`() = coroutinesExt.runTest {
-        every { remoteConfig.getValue(DarkModeTestExperiment.key.key) } returns FakeFirebaseRemoteConfigValue("true")
+        every {
+            remoteConfig.getValue(DarkModeTestExperiment.key.stringValue)
+        } returns FakeFirebaseRemoteConfigValue("true")
 
         val variant: Either<FeatureToggleDataSourceError, ExperimentVariant> = loadVariant(DarkModeTestExperiment.key)
 
@@ -102,7 +104,7 @@ class FirebaseDataSourceTest {
     @DisplayName("getAssignedVariant() should return ExperimentNotFound for an experiment not created on server")
     fun getAssignedVariantNoExperiment() = coroutinesExt.runTest {
         every {
-            remoteConfig.getValue(HomeScreenGameCardTestExperiment.key.key)
+            remoteConfig.getValue(HomeScreenGameCardTestExperiment.key.stringValue)
         } returns FakeFirebaseRemoteConfigValue("", source = FirebaseRemoteConfig.VALUE_SOURCE_STATIC)
 
         val variant = loadVariant(HomeScreenGameCardTestExperiment.key)
@@ -113,7 +115,7 @@ class FirebaseDataSourceTest {
     @Test
     fun `getAssignedVariant() should return DataSourceError on deserialization error`() = coroutinesExt.runTest {
         every {
-            remoteConfig.getValue(DarkModeTestExperiment.key.key)
+            remoteConfig.getValue(DarkModeTestExperiment.key.stringValue)
         } returns FakeFirebaseRemoteConfigValue("Value in unknown format")
 
         val variant = loadVariant(HomeScreenGameCardTestExperiment.key)
@@ -124,7 +126,7 @@ class FirebaseDataSourceTest {
     @Test
     fun `getAssignedVariant() should return DataSourceError on unknown experiment`() = coroutinesExt.runTest {
         every {
-            remoteConfig.getValue(DtfIntegrationTestExperiment.key.key)
+            remoteConfig.getValue(DtfIntegrationTestExperiment.key.stringValue)
         } returns FakeFirebaseRemoteConfigValue("true")
 
         val variant = loadVariant(DtfIntegrationTestExperiment.key)

--- a/foundation/featuretoggles/datasource-overrides/src/main/kotlin/ru/pixnews/foundation/featuretoggles/datasource/overrides/OverridesDataSource.kt
+++ b/foundation/featuretoggles/datasource-overrides/src/main/kotlin/ru/pixnews/foundation/featuretoggles/datasource/overrides/OverridesDataSource.kt
@@ -120,7 +120,7 @@ public class OverridesDataSource constructor(
         overrides: Overrides,
         experimentKey: ExperimentKey,
     ): Either<FeatureToggleDataSourceError, ExperimentVariant> {
-        val variant = overrides.getTogglesOrDefault(experimentKey.key, null)
+        val variant = overrides.getTogglesOrDefault(experimentKey.stringValue, null)
             ?: return ExperimentNotFound.completeFailure()
         return try {
             variant.deserialize(experimentKey).right()
@@ -149,11 +149,11 @@ public class OverridesDataSource constructor(
                 val payload: String = serializers[experimentKey]?.toString(experimentKey, variant)
                     ?: throw FeatureToggleException("No serializer for experiment `$experimentKey` found")
                 overrides.toBuilder()
-                    .putToggles(experimentKey.key, VariantPayload.newBuilder().setPayload(payload).build())
+                    .putToggles(experimentKey.stringValue, VariantPayload.newBuilder().setPayload(payload).build())
                     .build()
             } else {
                 overrides.toBuilder()
-                    .removeToggles(experimentKey.key)
+                    .removeToggles(experimentKey.stringValue)
                     .build()
             }
         }

--- a/foundation/featuretoggles/datasource-overrides/src/test/kotlin/ru/pixnews/foundation/featuretoggles/datasource/overrides/DataStoreHelper.kt
+++ b/foundation/featuretoggles/datasource-overrides/src/test/kotlin/ru/pixnews/foundation/featuretoggles/datasource/overrides/DataStoreHelper.kt
@@ -39,7 +39,7 @@ internal fun populateDataStoreFile(
             .map { (key, variant) ->
                 val payloadString = serializers[key]?.toString(key, variant)
                     ?: throw FeatureToggleException("No serializer for experiment `$key` found")
-                key.key to VariantPayload.newBuilder().setPayload(payloadString).build()
+                key.stringValue to VariantPayload.newBuilder().setPayload(payloadString).build()
             }
             .toMap()
         data.toBuilder().putAllToggles(toggles).build()

--- a/foundation/featuretoggles/pub/main/ru/pixnews/foundation/featuretoggles/pub/ExperimentKey.kt
+++ b/foundation/featuretoggles/pub/main/ru/pixnews/foundation/featuretoggles/pub/ExperimentKey.kt
@@ -16,10 +16,14 @@
 package ru.pixnews.foundation.featuretoggles.pub
 
 @JvmInline
-public value class ExperimentKey(public val key: String) {
+public value class ExperimentKey(public val stringValue: String) {
     init {
-        require(key.matches(KEY_FORMAT_REGEX)) { "Experiment key `$key` should match experiment key format" }
+        require(stringValue.matches(KEY_FORMAT_REGEX)) {
+            "Experiment key `$stringValue` should match experiment key format"
+        }
     }
+
+    override fun toString(): String = stringValue
 
     private companion object {
         private val KEY_FORMAT_REGEX: Regex = """[a-z0-9._-]+""".toRegex()

--- a/foundation/featuretoggles/pub/main/ru/pixnews/foundation/featuretoggles/pub/ExperimentVariantKey.kt
+++ b/foundation/featuretoggles/pub/main/ru/pixnews/foundation/featuretoggles/pub/ExperimentVariantKey.kt
@@ -20,10 +20,12 @@ package ru.pixnews.foundation.featuretoggles.pub
  * Usually the name for the group of users who will get access to this variant.
  */
 @JvmInline
-public value class ExperimentVariantKey(public val key: String) {
+public value class ExperimentVariantKey(public val stringValue: String) {
     init {
-        require(key.matches(KEY_VARIANT_FORMAT_REGEX))
+        require(stringValue.matches(KEY_VARIANT_FORMAT_REGEX))
     }
+
+    override fun toString(): String = stringValue
 
     public companion object {
         private val KEY_VARIANT_FORMAT_REGEX: Regex = """[a-z0-9._-]+""".toRegex()

--- a/foundation/featuretoggles/pub/testFixtures/ru/pixnews/foundation/featuretoggles/fixtures/TestExperiments.kt
+++ b/foundation/featuretoggles/pub/testFixtures/ru/pixnews/foundation/featuretoggles/fixtures/TestExperiments.kt
@@ -61,7 +61,7 @@ public object HomeScreenGameCardTestExperiment : Experiment {
     override val variants: Map<ExperimentVariantKey, Variant> = listOf(ControlGroup, V1Group, V2Group, V3Group, V4Group)
         .associateBy(ExperimentVariant::key)
 
-    public object Serializer : StringVariantSerializer(variants.mapKeys { it.key.key })
+    public object Serializer : StringVariantSerializer(variants.mapKeys { it.key.stringValue })
     public sealed class Variant : ExperimentVariant {
         public object ControlGroup : Variant() {
             override val key: ExperimentVariantKey = CONTROL_GROUP


### PR DESCRIPTION
Rename key to StringValue on experimentKey and experimentVariantKey for clarity

Also simplify toString()