### PR TITLE
Switch to ParallelGC, fine-tune JVM settings

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -15,14 +15,14 @@ concurrency:
 env:
   CI: true
   TERM: dumb
-  GRADLE_OPTS: >
-    -Dorg.gradle.jvmargs="-Xmx4G -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC"
-    -Dorg.gradle.parallel=true
+  GRADLE_OPTS: >-
+    -Dorg.gradle.jvmargs="-Xmx3G -XX:MaxMetaspaceSize=1g -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC"
     -Dorg.gradle.workers.max=2
     -Dorg.gradle.vfs.watch=false
     -Dorg.gradle.dependency.verification.console=verbose
-    -Dkotlin.compiler.execution.strategy=in-process
     -DwarningsAsErrors=false
+  KOTLIN_DAEMON_JVMARGS: >-
+    -Xmx2G -XX:MaxMetaspaceSize=320M -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC -XX:NewRatio=1
 
 jobs:
   assemble:
@@ -55,7 +55,9 @@ jobs:
       - name: Assemble debug build, run tests
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: assembleDebug test --stacktrace
+          arguments: |
+            -Pkotlin.daemon.jvmargs="${{ env.KOTLIN_DAEMON_JVMARGS }}"
+            assembleDebug test --stacktrace
 
       - name: Cleanup secrets
         if: ${{ always() }}
@@ -132,7 +134,9 @@ jobs:
       - name: Run static code analyzers
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: styleCheck --continue
+          arguments: |
+            -Pkotlin.daemon.jvmargs="${{ env.KOTLIN_DAEMON_JVMARGS }}"
+            styleCheck --continue
 
       - name: Cleanup secrets
         if: ${{ always() }}

--- a/.github/workflows/BuildOnPushMain.yml
+++ b/.github/workflows/BuildOnPushMain.yml
@@ -20,14 +20,15 @@ concurrency:
 env:
   CI: true
   TERM: dumb
-  GRADLE_OPTS: >
-    -Dorg.gradle.jvmargs="-Xmx4G -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC"
+  GRADLE_OPTS: >-
+    -Dorg.gradle.jvmargs="-Xmx1536M -XX:MaxMetaspaceSize=1g -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC"
     -Dorg.gradle.parallel=true
     -Dorg.gradle.workers.max=2
     -Dorg.gradle.vfs.watch=false
     -Dorg.gradle.dependency.verification.console=verbose
-    -Dkotlin.compiler.execution.strategy=in-process
     -DwarningsAsErrors=false
+  KOTLIN_DAEMON_JVMARGS: >-
+    -Xmx1536M -XX:MaxMetaspaceSize=320M -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC -XX:NewRatio=1
 
 jobs:
   assemble:
@@ -60,7 +61,9 @@ jobs:
       - name: Assemble release build, run static-analysis, build release
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: lintRelease assembleRelease --stacktrace
+          arguments: |
+            -Pkotlin.daemon.jvmargs="${{ env.KOTLIN_DAEMON_JVMARGS }}"
+            lintRelease assembleRelease --stacktrace
 
       - name: Cleanup secrets
         if: ${{ always() }}
@@ -143,6 +146,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
+            -Pkotlin.daemon.jvmargs="${{ env.KOTLIN_DAEMON_JVMARGS }}"
             -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
             -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
             cleanManagedDevices --unused-only
@@ -152,6 +156,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
+            -Pkotlin.daemon.jvmargs="${{ env.KOTLIN_DAEMON_JVMARGS }}"
             -Dorg.gradle.workers.max=1
             -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
             -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true

--- a/.github/workflows/InstrumentedTestOnSelfHostedRunner.yml
+++ b/.github/workflows/InstrumentedTestOnSelfHostedRunner.yml
@@ -20,14 +20,15 @@ concurrency:
 env:
   CI: true
   TERM: dumb
-  GRADLE_OPTS: >
-    -Dorg.gradle.jvmargs="-Xmx2G -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseG1GC"
+  GRADLE_OPTS: >-
+    -Dorg.gradle.jvmargs="-Xmx1536M -XX:MaxMetaspaceSize=1g -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC"
     -Dorg.gradle.parallel=true
     -Dorg.gradle.workers.max=2
     -Dorg.gradle.vfs.watch=false
     -Dorg.gradle.dependency.verification.console=verbose
-    -Dkotlin.compiler.execution.strategy=in-process
     -DwarningsAsErrors=false
+  KOTLIN_DAEMON_JVMARGS: >-
+    -Xmx1536M -XX:MaxMetaspaceSize=320M -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC -XX:NewRatio=1
 
 jobs:
   instrumented-tests:
@@ -66,6 +67,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
+            -Pkotlin.daemon.jvmargs="${{ env.KOTLIN_DAEMON_JVMARGS }}"
             -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
             -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
             cleanManagedDevices --unused-only
@@ -75,6 +77,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
+            -Pkotlin.daemon.jvmargs="${{ env.KOTLIN_DAEMON_JVMARGS }}"
             -Dorg.gradle.workers.max=1
             -Pandroid.testoptions.manageddevices.emulator.gpu=swiftshader_indirect
             -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,10 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8  \
-  -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError \
-  -XX:+UseG1GC
+org.gradle.jvmargs=-Dfile.encoding=UTF-8  \
+  -Xmx2G -XX:MaxMetaspaceSize=1G -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC \
+  -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 \
+  -Xmx2G -XX:MaxMetaspaceSize=320M -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC -XX:NewRatio=1 \
+  -XX:+HeapDumpOnOutOfMemoryError
+
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.unsafe.configuration-cache=true
@@ -22,9 +26,6 @@ kotlin.code.style=official
 
 # Kapt controls
 kapt.include.compile.classpath=false
-
-# https://docs.gradle.org/7.6/userguide/upgrading_version_7.html#strict-kotlin-dsl-precompiled-scripts-accessors
-systemProp.org.gradle.kotlin.dsl.precompiled.accessors.strict=true
 
 # Default Android build features
 android.defaults.buildfeatures.resvalues=false

--- a/gradle/base-kotlin-dsl-plugin/gradle.properties
+++ b/gradle/base-kotlin-dsl-plugin/gradle.properties
@@ -1,6 +1,10 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8  \
-  -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError \
-  -XX:+UseG1GC
+org.gradle.jvmargs=-Dfile.encoding=UTF-8  \
+  -Xmx2G -XX:MaxMetaspaceSize=1G -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC \
+  -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 \
+  -Xmx2G -XX:MaxMetaspaceSize=320M -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC -XX:NewRatio=1 \
+  -XX:+HeapDumpOnOutOfMemoryError
+
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.unsafe.configuration-cache=true

--- a/gradle/meta-plugins/gradle.properties
+++ b/gradle/meta-plugins/gradle.properties
@@ -1,6 +1,10 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8  \
-  -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError \
-  -XX:+UseG1GC
+org.gradle.jvmargs=-Dfile.encoding=UTF-8  \
+  -Xmx2G -XX:MaxMetaspaceSize=1G -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC \
+  -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 \
+  -Xmx2G -XX:MaxMetaspaceSize=320M -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC -XX:NewRatio=1 \
+  -XX:+HeapDumpOnOutOfMemoryError
+
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.unsafe.configuration-cache=true

--- a/gradle/plugins/gradle.properties
+++ b/gradle/plugins/gradle.properties
@@ -1,6 +1,10 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8  \
-  -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError \
-  -XX:+UseG1GC
+org.gradle.jvmargs=-Dfile.encoding=UTF-8  \
+  -Xmx2G -XX:MaxMetaspaceSize=1G -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC \
+  -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 \
+  -Xmx2G -XX:MaxMetaspaceSize=320M -XX:SoftRefLRUPolicyMSPerMB=10 -XX:+UseParallelGC -XX:NewRatio=1 \
+  -XX:+HeapDumpOnOutOfMemoryError
+
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.unsafe.configuration-cache=true


### PR DESCRIPTION
* ParallelGC as a garbage collector
* Change Kotlin compiler execution strategy from "in-process" to "daemon"
* Increase memory for the Kotlin Daemon.
* Fine-tune `MaxMetaspaceSize` both for the Kotlin Daemon and Gradle Daemon
* `-XX:SoftRefLRUPolicyMSPerMB=10`in an attempt to reduce memory consumption on reusing Kotlin and Gradle daemons. Also to reduce number of Full GC cycles caused by metaspace exhaustion